### PR TITLE
Improve project Id input

### DIFF
--- a/playground/components/ProjectInput.vue
+++ b/playground/components/ProjectInput.vue
@@ -19,13 +19,9 @@
   const fileInput = ref(null);
   const error = ref(null);
   const goDisabled = ref(true);
-  watch(projId, () => {
+  watch(projId, (newVal) => {
     projId.value = newVal.toString().replaceAll(/[^\d]/g, '');
-    if (projId.value === "") {
-      goDisabled.value = true;
-      return;
-    }
-    goDisabled.value = false;
+    goDisabled.value = projId.value === "";
   });
   
   function handleNumInput() {


### PR DESCRIPTION
This PR aims to implement the changes suggested on https://github.com/HyperQuark/hyperquark/issues/26 doing the following changes:
- remove placeholder from the input;
- keep the `Go!` disabled, until a `valid` project Id is typed;
  - `valid` here means:
    - only digits;
    - gets `200` response when tested against `https://trampoline.turbowarp.org/api/projects/${projectId}/`; The usage of `HEAD` method is a slight optimization to get the minimal response, since this request might get re-done later if the user hits the `Go!` button;



If approved, this PR closes https://github.com/HyperQuark/hyperquark/issues/26.