### PR TITLE
fix: submit project IDs through a form

### DIFF
--- a/playground/components/ProjectInput.vue
+++ b/playground/components/ProjectInput.vue
@@ -4,24 +4,22 @@
     {{ error }}
   </details>
   <template v-else>
-    <span class=".inline-block"
-      >Enter a project id:
-      <span
-        class="projinput inline-block"
-        tabindex="0"
-        @focus="() => numInput.focus()"
-        >https://scratch.mit.edu/projects/<input
-          type="text"
-          ref="numInput"
-          v-model="projId" /></span
-      ><button
-        @click="handleNumInput"
-        :disabled="goDisabled"
-        :title="buttonTooltip"
-      >
+    <form class="inline-block" @submit.prevent="handleNumInput">
+      <label for="project-id"
+        >Enter a project ID:
+        <span class="projinput inline-block"
+          >https://scratch.mit.edu/projects/<input
+            id="project-id"
+            type="text"
+            ref="numInput"
+            v-model="projId"
+            inputmode="numeric"
+            required /></span
+      ></label>
+      <button type="submit" :disabled="goDisabled" :title="buttonTooltip">
         Go!
-      </button></span
-    >
+      </button>
+    </form>
     <span class="inline-block"
       >or upload a project: <ProjectFileInput @error="err"></ProjectFileInput
     ></span>


### PR DESCRIPTION
## Summary

- submit the project ID through a semantic form so Enter and the Go button use the same path
- explicitly associate the label with the input and remove the extra wrapper tab stop
- mark the field required and request a numeric keyboard while preserving the existing digit filtering

Closes #70.

## Verification

- `npm ci` with Node.js 22.23.1 / npm 10.9.8
- `npm run format:check`
- parsed and compiled `ProjectInput.vue` with `@vue/compiler-sfc`; verified the generated render includes the submit handler, prevent modifier, label target, and required input
- direct `npm run build` and `npm test -- --run` on a clean checkout reach the existing prerequisite failure for untracked generated WASM/JS modules; the repository CI creates those modules with `build.sh -Wpz` before its integration test